### PR TITLE
Updates to delete_resp_cookie for Signout

### DIFF
--- a/priv/templates/lib/web/controllers/veil/session_controller.ex
+++ b/priv/templates/lib/web/controllers/veil/session_controller.ex
@@ -35,7 +35,7 @@ defmodule <%= web_module %>.Veil.SessionController do
     with {:ok, _session} <- Veil.delete_session(session_unique_id) do
       <%= if html? do %>
       conn
-      |> put_resp_cookie("session_unique_id", nil, max_age: 60*60*24*365)
+      |> delete_resp_cookie("session_unique_id", max_age: 60*60*24*365)
       |> redirect(to: user_path(conn, :new))
       <% else %>
       conn


### PR DESCRIPTION
Using `put_resp_cookie` with a value of `nil` was raising an exception. This just updates to use `delete_resp_cookie` to delete the cookie.