### PR TITLE
Make Plug dependency explicit

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule Veil.MixProject do
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:swoosh, "~> 0.13"},
       {:phoenix_swoosh, "~> 0.2"},
-      {:quantum, "~> 2.2"}
+      {:quantum, "~> 2.2"},
+      {:plug, "~> 1.3"}
     ]
   end
 


### PR DESCRIPTION
`Veil.Secure` uses `Plug.Conn.get_req_header/2`. The Plug dependency should be explicit.

Version 1.3 is currently the oldest [supported version](https://github.com/elixir-plug/plug#supported-versions).