### PR TITLE
Fix assigning of :veil_user in generated Plugs.Veil.User

### DIFF
--- a/priv/templates/lib/web/plugs/veil/user.ex
+++ b/priv/templates/lib/web/plugs/veil/user.ex
@@ -10,7 +10,8 @@ defmodule <%= web_module %>.Plugs.Veil.User do
 
   def call(conn, _opts) do
     if veil_user_id = conn.assigns[:veil_user_id] do
-      assign(conn, :veil_user, Veil.get_user(veil_user_id))
+      {:ok, veil_user} = Veil.get_user(veil_user_id)
+      assign(conn, :veil_user, veil_user)
     else
       conn
     end


### PR DESCRIPTION
If I'm not mistaken [`Veil.get_user/1`](https://github.com/zanderxyz/veil/blob/master/priv/templates/lib/main/veil/veil.ex#L18-L20) just calls [`Veil.Cache.get_or_update/3`](https://github.com/zanderxyz/veil/blob/master/lib/veil/cache.ex#L26-L36), which returns an `{:ok, value}` tuple, so we should correctly handle this in the generated `MyAppWeb.Plugs.Veil.User` file.