### PR TITLE
Use headers for api calls to make API an HTML requests more aligned.

### DIFF
--- a/priv/templates/lib/web/plugs/veil/user_id.ex
+++ b/priv/templates/lib/web/plugs/veil/user_id.ex
@@ -15,7 +15,7 @@ defmodule <%= web_module %>.Plugs.Veil.UserId do
     with session_unique_id <- conn.cookies["session_unique_id"],
   <% else %>
   def call(conn, _opts) do
-    with [session_unique_id|_] = get_req_header(conn, "session_unique_id"),
+    with [session_unique_id|_] <- get_req_header(conn, "session_unique_id"),
   <% end %>
          {:ok, session} <- Veil.get_session(session_unique_id),
          {:ok, user_id} <- Veil.verify(conn, session),

--- a/priv/templates/lib/web/plugs/veil/user_id.ex
+++ b/priv/templates/lib/web/plugs/veil/user_id.ex
@@ -1,22 +1,23 @@
 defmodule <%= web_module %>.Plugs.Veil.UserId do
   @moduledoc """
   A plug to verify if the client is logged in.
-  If the client has a session id set as a cookie, we verify if it is valid and unexpired and
-  assign their user_id to the conn. It can now be accessed using conn.assigns[:veil_user_id].
+  If the client has a session id set as a cookie or api request header, we
+  verify if it is valid and unexpired and assign their user_id to the conn. It
+  can now be accessed using conn.assigns[:veil_user_id].
   """
   import Plug.Conn
   alias <%= main_module %>.Veil
 
   def init(default), do: default
 
-  <%= if html? do %>
   def call(conn, _opts) do
+  <%= if html? do %>
     with session_unique_id <- conn.cookies["session_unique_id"],
-         {:ok, session} <- Veil.get_session(session_unique_id),
   <% else %>
-  def call(%Plug.Conn{params: %{"session_id" => session_unique_id}} = conn, _opts) do
-    with {:ok, session} <- Veil.get_session(session_unique_id),
+  def call(conn, _opts) do
+    with [session_unique_id|_] = get_req_header(conn, "session_unique_id"),
   <% end %>
+         {:ok, session} <- Veil.get_session(session_unique_id),
          {:ok, user_id} <- Veil.verify(conn, session),
          true <- Kernel.==(user_id, session.user_id) do
       Task.start(fn -> Veil.extend_session(conn, session) end)


### PR DESCRIPTION
When making api requests I find that having the "authentication" part of the request, in this case the `session_id` is easier to manage as a header key. This way request parameters are no combined with the information needed for identity verification.