### PR TITLE
Fix error if --no-html

### DIFF
--- a/priv/templates/lib/web/plugs/veil/user_id.ex
+++ b/priv/templates/lib/web/plugs/veil/user_id.ex
@@ -14,7 +14,6 @@ defmodule <%= web_module %>.Plugs.Veil.UserId do
   <%= if html? do %>
     with session_unique_id <- conn.cookies["session_unique_id"],
   <% else %>
-  def call(conn, _opts) do
     with [session_unique_id|_] <- get_req_header(conn, "session_unique_id"),
   <% end %>
          {:ok, session} <- Veil.get_session(session_unique_id),


### PR DESCRIPTION
I noticed if you use this with --no-html in your phoenix build, there is an error with user_id.ex. This change seems to fix it, but apologies if I got that wrong.